### PR TITLE
:art: 기본 뷰 구현 완료

### DIFF
--- a/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother.xcodeproj/project.pbxproj
+++ b/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		912A93FCF008DEC8C2D9A8D9 /* Pods_Starbucks_Clone_TexBrother.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D008B44055C8D19550BEAF50 /* Pods_Starbucks_Clone_TexBrother.framework */; };
+		CC2F69D0270D45CF009E4F1C /* ASDisplayNode+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2F69CF270D45CF009E4F1C /* ASDisplayNode+.swift */; };
 		CC3806FD2703F76F006AA4AF /* CardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3806FC2703F76F006AA4AF /* CardModel.swift */; };
 		CC3806FF2703F7C7006AA4AF /* PayCardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3806FE2703F7C7006AA4AF /* PayCardCollectionViewCell.swift */; };
 		CC3807022703FAD1006AA4AF /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3807012703FAD0006AA4AF /* UIColor+.swift */; };
@@ -28,6 +29,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		CC2F69CF270D45CF009E4F1C /* ASDisplayNode+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASDisplayNode+.swift"; sourceTree = "<group>"; };
 		CC3806FC2703F76F006AA4AF /* CardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardModel.swift; sourceTree = "<group>"; };
 		CC3806FE2703F7C7006AA4AF /* PayCardCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayCardCollectionViewCell.swift; sourceTree = "<group>"; };
 		CC3807012703FAD0006AA4AF /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 			children = (
 				CC3807012703FAD0006AA4AF /* UIColor+.swift */,
 				CC3807032704018C006AA4AF /* CALayer+.swift */,
+				CC2F69CF270D45CF009E4F1C /* ASDisplayNode+.swift */,
 			);
 			path = UIExtensions;
 			sourceTree = "<group>";
@@ -333,6 +336,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CCDD92BC26FA28C7008B3D8A /* ViewController.swift in Sources */,
+				CC2F69D0270D45CF009E4F1C /* ASDisplayNode+.swift in Sources */,
 				CC3807042704018C006AA4AF /* CALayer+.swift in Sources */,
 				CCDD92E326FB043E008B3D8A /* PayMenuNode.swift in Sources */,
 				CCDD92DA26FA2DA3008B3D8A /* PayNodeController.swift in Sources */,

--- a/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother/Global/Customs/CustomNavigationBar.swift
+++ b/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother/Global/Customs/CustomNavigationBar.swift
@@ -17,7 +17,6 @@ class CustomNavigationBar: ASDisplayNode {
     
     let backButton: ASButtonNode = {
         let node = ASButtonNode()
-        node.backgroundColor = .black
         node.style.preferredSize = CGSize(width: 15, height: 15)
         return node
     }()
@@ -30,7 +29,6 @@ class CustomNavigationBar: ASDisplayNode {
     
     let rightButton: ASButtonNode = {
         let node = ASButtonNode()
-        node.backgroundColor = .black
         node.isHidden = true
         node.style.preferredSize = CGSize(width: 15, height: 15)
         return node
@@ -40,6 +38,8 @@ class CustomNavigationBar: ASDisplayNode {
     
     override init() {
         super.init()
+        automaticallyManagesSubnodes = true
+        automaticallyRelayoutOnSafeAreaChanges = true
     }
 }
 
@@ -55,7 +55,20 @@ extension CustomNavigationBar {
             spacing: 0,
             justifyContent: .spaceBetween,
             alignItems: .center,
-            children: [backButton, titleLabel, rightButton]
+            children:
+                [
+                    backButton.styled {
+                        $0.preferredSize = CGSize(width: 21, height: 19)
+                        $0.flexGrow = 0.5
+                    },
+                    titleLabel.styled {
+                        $0.flexShrink = 1.0
+                    },
+                    rightButton.styled {
+                        $0.preferredSize = CGSize(width: 21, height: 19)
+                        $0.flexGrow = 0.5
+                    }
+                ]
         )
     }
     

--- a/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother/Global/UIExtensions/ASDisplayNode+.swift
+++ b/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother/Global/UIExtensions/ASDisplayNode+.swift
@@ -1,16 +1,17 @@
 //
-//  CALayer+.swift
+//  ASDisplayNode+.swift
 //  Starbucks_Clone_TexBrother
 //
-//  Created by 노한솔 on 2021/09/29.
+//  Created by 노한솔 on 2021/10/06.
+//
 
+import AsyncDisplayKit
 
-import UIKit
-
-extension CALayer {
+extension ASDisplayNode {
+    
     func applyCardShadow(
         color: UIColor = .black,
-        alpha: Float = 0.16,
+        alpha: CGFloat = 0.16,
         x: CGFloat = 0,
         y: CGFloat = 3,
         blur: CGFloat = 6
@@ -19,5 +20,6 @@ extension CALayer {
         shadowOpacity = alpha
         shadowOffset = CGSize(width: x, height: y)
         shadowRadius = blur / 1.0
+        clipsToBounds = false
     }
 }

--- a/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother/Screens/Pay/Cells/PayCardCollectionViewCell.swift
+++ b/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother/Screens/Pay/Cells/PayCardCollectionViewCell.swift
@@ -17,12 +17,13 @@ final class PayCardCollectionViewCell: ASCellNode {
     
     private let cardImageNode: ASImageNode = {
        let node = ASImageNode()
-        node.style.preferredSize = CGSize(width: 296, height: 186)
+        node.contentMode = .scaleAspectFill
         return node
     }()
     
     private let titleLabelNode: ASTextNode = {
         let node = ASTextNode()
+        node.style.flexShrink = 1.0
         return node
     }()
     
@@ -41,6 +42,7 @@ final class PayCardCollectionViewCell: ASCellNode {
     private let barcodeImageNode: ASImageNode = {
         let node = ASImageNode()
         node.image = UIImage(named: "barcode")
+        node.contentMode = .scaleAspectFit
         return node
     }()
     
@@ -90,6 +92,7 @@ final class PayCardCollectionViewCell: ASCellNode {
         let node = ASImageNode()
         node.image = UIImage(named: "autoChargeIcon")
         node.style.preferredSize = CGSize(width: 27.5, height: 21.3)
+        node.style.flexGrow = 1.0
         return node
     }()
     
@@ -115,6 +118,7 @@ final class PayCardCollectionViewCell: ASCellNode {
         let node = ASImageNode()
         node.image = UIImage(named: "generalChargeIcon")
         node.style.preferredSize = CGSize(width: 27.5, height: 21.3)
+        node.style.flexGrow = 1.0
         return node
     }()
     
@@ -132,10 +136,23 @@ final class PayCardCollectionViewCell: ASCellNode {
     
     // MARK: - LifeCycles
     
-    override init() {
+    init(model: CardModel?) {
         super.init()
         self.automaticallyManagesSubnodes = true
         self.automaticallyRelayoutOnSafeAreaChanges = true
+        
+        if let card = model {
+            dataBind(cardImage: card.cardImageName, title: card.title, price: card.price, isFavorite: false)
+        }
+    }
+    
+    override func didLoad() {
+        super.didLoad()
+        self.applyCardShadow()
+    }
+    
+    override func layout() {
+        super.layout()
     }
 }
 
@@ -151,7 +168,6 @@ extension PayCardCollectionViewCell {
         priceLabelNode.style.spacingAfter = 13
         barcodeImageNode.style.spacingAfter = 6
         cardNumberTextNode.style.spacingAfter = 8
-        validationLayoutSpec().style.spacingAfter = 33
         
         let layout = ASStackLayoutSpec(
             direction: .vertical,
@@ -159,12 +175,16 @@ extension PayCardCollectionViewCell {
             justifyContent: .center,
             alignItems: .center,
             children: [
-                cardImageNode,
+                cardImageNode.styled {
+                    $0.height = ASDimension(unit: .points, value: 189)
+                },
                 titleLabelNode,
                 priceLabelNode,
                 barcodeImageNode,
                 cardNumberTextNode,
-                validationLayoutSpec(),
+                validationLayoutSpec().styled {
+                    $0.spacingAfter = 33
+                },
                 chargeLayoutSpec()
             ]
         )

--- a/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother/Screens/Pay/Nodes/PayMenuNode.swift
+++ b/Starbucks_Clone_TexBrother/Starbucks_Clone_TexBrother/Screens/Pay/Nodes/PayMenuNode.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import AsyncDisplayKit
+import UIKit
 
 // MARK: - PayMenuNode
 
@@ -32,7 +33,6 @@ final class PayMenuNode: ASDisplayNode {
     private let separatorView: ASDisplayNode = {
         let node = ASDisplayNode()
         node.backgroundColor = .gray
-        node.style.preferredSize = CGSize(width: 1, height: 5)
         return node
     }()
     
@@ -40,6 +40,12 @@ final class PayMenuNode: ASDisplayNode {
     
     override init() {
         super.init()
+        automaticallyManagesSubnodes = true
+        automaticallyRelayoutOnSafeAreaChanges = true
+    }
+    
+    override func layout() {
+        super.layout()
     }
 }
 
@@ -55,7 +61,20 @@ extension PayMenuNode {
             spacing: 0,
             justifyContent: .spaceAround,
             alignItems: .center,
-            children: [couponButton, separatorView, giftButton]
+            children:
+                [
+                    couponButton.styled {
+                        $0.flexShrink = 0.5
+                        $0.preferredSize = CGSize(width: UIScreen.main.bounds.width-1/2, height: 30)
+                    },
+                    separatorView.styled {
+                        $0.preferredSize = CGSize(width: 1, height: 10)
+                    },
+                    giftButton.styled {
+                        $0.flexShrink = 0.5
+                        $0.preferredSize = CGSize(width: UIScreen.main.bounds.width-1/2, height: 30)
+                    }
+                ]
         )
     }
 }


### PR DESCRIPTION
<!-- Linked issues -->
TexBrother/TexBrother-Hansol#2
<!-- EXAMPLE ->
<!-- TexBrother/TexBrother-Hansol#1 -->

## Summary

카드뷰 셀 세팅
스크롤 뷰 배열 정리

## Sth Coming Newly
<!-- 새로 알게된 것은 무엇인지 -->

뭔가,,, 변수 선언할때 안먹는 것들이 LayoutSpec에서 children 선언할때 styled {} 블록 안에 쓰면 작동해요,,,
대체 왜져,,,?

## Challenges
<!-- 가장 어려웠던 점은 무엇이었고 어떻게 해결했는지 -->

preferredSize가 안먹어서 계속 애먹었는데 LayoutSpec에 쓰니까 되더라구요,,,?
이걸로만 정말 오래 고민했는데,,,,,,

## References
<!-- 관련 자료가 있을 경우 첨부 및 링크 추가 -->
